### PR TITLE
fix: attrValueMapper fails to parse complex AttributeValue tags (#245)

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -1008,10 +1008,6 @@ SAML.prototype.processValidlySignedAssertion = function(xml, samlResponseXml, in
                                                   .map(attr => attr.Attribute)
                                );
 
-      var attrValueMapper = function(value) {
-        return typeof value === 'string' ? value : value._;
-      };
-
       if (attributes) {
         attributes.forEach(attribute => {
          if(!Object.prototype.hasOwnProperty.call(attribute, 'AttributeValue')) {
@@ -1020,9 +1016,9 @@ SAML.prototype.processValidlySignedAssertion = function(xml, samlResponseXml, in
           }
           var value = attribute.AttributeValue;
           if (value.length === 1) {
-            profile[attribute.$.Name] = attrValueMapper(value[0]);
+            profile[attribute.$.Name] = this.attributeValueMapper(value[0]);
           } else {
-            profile[attribute.$.Name] = value.map(attrValueMapper);
+            profile[attribute.$.Name] = value.map(this.attributeValueMapper);
           }
         });
       }
@@ -1303,6 +1299,18 @@ SAML.prototype.keyToPEM = function (key) {
     ''
   ].join('\n');
   return wrappedKey;
+};
+
+SAML.prototype.attributeValueMapper = function (value) {
+  if(typeof value === 'string') {
+    return value;
+  } else if (typeof value._ === 'string') {
+    return value._;
+  } else if (value.NameID && value.NameID[0]) {
+    return Object.assign({
+      Value: value.NameID[0]._
+    }, value.NameID[0].$ || {});
+  }
 };
 
 exports.SAML = SAML;

--- a/test/static/attributes-values-sample.js
+++ b/test/static/attributes-values-sample.js
@@ -1,0 +1,109 @@
+module.exports = [
+  {
+    $: {
+      FriendlyName: "mail",
+      Name: "urn:oid:0.9.2342.19200300.100.1.3",
+      NameFormat: "urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+    },
+    AttributeValue: [
+      {
+        _: "example-user@example-university.edu",
+        $: {
+          "xmlns:xsd": "http://www.w3.org/2001/XMLSchema",
+          "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+          "xsi:type": "xsd:string"
+        }
+      }
+    ]
+  },
+  {
+    $: {
+      FriendlyName: "eduPersonTargetedID",
+      Name: "urn:oid:1.3.6.1.4.1.5923.1.1.1.10",
+      NameFormat: "urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+    },
+    AttributeValue: [
+      {
+        NameID: [
+          {
+            _: "SBJMMcDv00BWSefyNqumyK0A+Jb=",
+            $: {
+              Format: "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+              NameQualifier:
+                "https://idp.example-university.edu/idp/shibboleth",
+              SPNameQualifier: "https://www.example-service-provider.com/entity"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    $: {
+      FriendlyName: "eduPersonPrimaryAffiliation",
+      Name: "urn:oid:1.3.6.1.4.1.5923.1.1.1.5",
+      NameFormat: "urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+    },
+    AttributeValue: [
+      {
+        _: "staff",
+        $: {
+          "xmlns:xsd": "http://www.w3.org/2001/XMLSchema",
+          "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+          "xsi:type": "xsd:string"
+        }
+      }
+    ]
+  },
+  {
+    $: {
+      FriendlyName: "displayName",
+      Name: "urn:oid:2.16.840.1.113730.3.1.241",
+      NameFormat: "urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+    },
+    AttributeValue: [
+      {
+        _: "Smith John",
+        $: {
+          "xmlns:xsd": "http://www.w3.org/2001/XMLSchema",
+          "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+          "xsi:type": "xsd:string"
+        }
+      }
+    ]
+  },
+  {
+    $: {
+      FriendlyName: "givenName",
+      Name: "urn:oid:2.5.4.42",
+      NameFormat: "urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+    },
+    AttributeValue: [
+      {
+        _: "John",
+        $: {
+          "xmlns:xsd": "http://www.w3.org/2001/XMLSchema",
+          "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+          "xsi:type": "xsd:string"
+        }
+      }
+    ]
+  },
+  {
+    $: {
+      FriendlyName: "surname",
+      Name: "urn:oid:2.5.4.4",
+      NameFormat: "urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+    },
+    AttributeValue: [
+      {
+        _: "Smith",
+        $: {
+          "xmlns:xsd": "http://www.w3.org/2001/XMLSchema",
+          "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+          "xsi:type": "xsd:string"
+        }
+      }
+    ]
+  }
+];


### PR DESCRIPTION
# Context

This fixes an issue where the `attrValueMapper` would fail to properly map the value for complex `AttributeValue` tags. This handles the case where the `AttributeValue` contains a nested `NameID` tag.

One such example is the `eduPersonTargetedID` that is used as an identifier in [eduGAIN][1] which can return an Attribute of the form

```xml
<saml2:Attribute FriendlyName="eduPersonTargetedID" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.10" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
  <saml2:AttributeValue>
    <saml2:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent" NameQualifier="https://idp.example-university.fr/idp/shibboleth" SPNameQualifier="https://www.service-provider.com/shibboleth">a6c2c4d4-08b9-4ca7-8ff9-43d83e6e1d35</saml2:NameID>
  </saml2:AttributeValue>
</saml2:Attribute>
```

# Limitations

Note that in reality, the `AttributeValue` tags can be much more complex. [The Assertions and Protocols for the OASIS Security Assertion Markup Language (SAML) V2.0][2] uses the following schema for the `Attribute` tag:

```xml
<element name="Attribute" type="saml:AttributeType"/>
<complexType name="AttributeType">
  <sequence>
    <element ref="saml:AttributeValue" minOccurs="0" maxOccurs="unbounded"/>
  </sequence>
  <attribute name="Name" type="string" use="required"/>
  <attribute name="NameFormat" type="anyURI" use="optional"/>
  <attribute name="FriendlyName" type="string" use="optional"/>
  <anyAttribute namespace="##other" processContents="lax"/>
</complexType>
```

and the following schema for the `AttributeValue`:

```xml
<element name="AttributeValue" type="anyType" nillable="true"/>
```

which means it can take any type.

As pointed out in [this issue][3], it is customary to use `NameQualifier` and the `SPNameQualifier` in addition to the actual value to create a unique identifier for the platform. That is why the `AttributeValue` is mapped to an object containing the attribute of the `NameID` tag as well as the string value for `eduPersonTargetedID` that is stored in the `Value` property.

# Additional information regarding the fix

- The `attrValueMapper` is extracted to the SAML prototype to make it easier to test and it is renamed to `attributeValueMapper` to make it more explicit.
- Tests have been added to check that it correctly handles the use case where the AttributeValue contains a nested NameID tag.
- Previously, the `attrValueMapper` would return `undefined` for this use case. Now, it returns an object where `Value` is the nested string value and the tag attributes are properties of that object.

# Related PRs and issues

This should close the following PRs (although the mapping is different):
- https://github.com/bergie/passport-saml/pull/246
- https://github.com/bergie/passport-saml/pull/249

This should close the following issue:
- https://github.com/bergie/passport-saml/issues/245

[1]: https://wiki.geant.org/display/eduGAIN/Identifier+Attributes
[2]: https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf
[3]: https://github.com/bergie/passport-saml/issues/245#issuecomment-344575492